### PR TITLE
support road types with no speed limit; cross-platform make_tar.py

### DIFF
--- a/info.nut
+++ b/info.nut
@@ -35,21 +35,22 @@ class FMainClass extends GSInfo {
 	function GetSettings() {
 		AddSetting({name = "max_connected_towns", description = "Maximum number of neighbor towns to be connected", easy_value = 5, medium_value = 5, hard_value = 2, custom_value = 5, flags = CONFIG_NONE, min_value = 1, max_value = 16});
 
-		AddSetting({name = "connect_cities_to_cities", description = "----- Connect cities -----", easy_value = 1, medium_value = 1, hard_value = 1, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});
-		AddSetting({name = "max_distance_between_cities", description = "Maximum distance between cities", easy_value = 1024, medium_value = 512, hard_value = 256, custom_value = 512, flags = CONFIG_NONE, min_value = 20, max_value = 16384});
-		AddSetting({name = "restrict_speed_city_to_city", description = "Restrict maximum road speed for city to city connection", easy_value = 0, medium_value = 0, hard_value = 1, custom_value = 0, flags = CONFIG_NONE + CONFIG_BOOLEAN});
-		AddSetting({name = "speed_city_to_city", description = "Maximum road speed for city to city connection (km/h)", easy_value = 130, medium_value = 130, hard_value = 90, custom_value = 130, flags = CONFIG_NONE, min_value = 20, max_value = 255, step_size = 5});
+		AddSetting({name = "connect_cities_to_cities", description = "---------- Connect cities ----------", easy_value = 1, medium_value = 1, hard_value = 1, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});
+		AddSetting({name = "max_distance_between_cities", description = "Maximum distance between cities", easy_value = 512, medium_value = 256, hard_value = 128, custom_value = 512, flags = CONFIG_NONE, min_value = 20, max_value = 16384});
+		AddSetting({name = "restrict_speed_city_to_city", description = "Restrict maximum road speed for city to city connection", easy_value = 0, medium_value = 1, hard_value = 1, custom_value = 0, flags = CONFIG_NONE + CONFIG_BOOLEAN});
+		AddSetting({name = "speed_city_to_city", description = "Maximum road speed for city to city connection (km/h)", easy_value = 130, medium_value = 130, hard_value = 130, custom_value = 130, flags = CONFIG_NONE, min_value = 20, max_value = 255, step_size = 5});
 
-		AddSetting({name = "connect_towns_to_cities", description = "----- Connect towns to cities -----", easy_value = 1, medium_value = 1, hard_value = 0, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});
-		AddSetting({name = "max_distance_between_towns_and_cities", description = "Maximum distance between towns and cities", easy_value = 512, medium_value = 256, hard_value = 128, custom_value = 256, flags = CONFIG_NONE, min_value = 20, max_value = 16384});
-		AddSetting({name = "restrict_speed_town_to_city", description = "Restrict maximum road speed for town to city connection", easy_value = 0, medium_value = 1, hard_value = 1, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});		
-		AddSetting({name = "speed_town_to_city", description = "Maximum road speed for town to city connection (km/h)", easy_value = 110, medium_value = 90, hard_value = 70, custom_value = 90, flags = CONFIG_NONE, min_value = 20, max_value = 255, step_size = 5});
+		AddSetting({name = "connect_towns_to_cities", description = "---------- Connect towns to cities ----------", easy_value = 1, medium_value = 1, hard_value = 1, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});
+		AddSetting({name = "max_distance_between_towns_and_cities", description = "Maximum distance between towns and cities", easy_value = 256, medium_value = 128, hard_value = 64, custom_value = 256, flags = CONFIG_NONE, min_value = 20, max_value = 16384});
+		AddSetting({name = "restrict_speed_town_to_city", description = "Restrict maximum road speed for town to city connection", easy_value = 1, medium_value = 1, hard_value = 1, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});		
+		AddSetting({name = "speed_town_to_city", description = "Maximum road speed for town to city connection (km/h)", easy_value = 110, medium_value = 90, hard_value = 70, custom_value = 110, flags = CONFIG_NONE, min_value = 20, max_value = 255, step_size = 5});
 
-		AddSetting({name = "connect_towns_to_towns", description = "----- Connect towns to other towns -----", easy_value = 1, medium_value = 1, hard_value = 0, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});
-		AddSetting({name = "max_distance_between_towns_and_towns", description = "Maximum distance between towns", easy_value = 256, medium_value = 128, hard_value = 64, custom_value = 128, flags = CONFIG_NONE, min_value = 20, max_value = 16384});
+		AddSetting({name = "connect_towns_to_towns", description = "---------- Connect towns to other towns ----------", easy_value = 1, medium_value = 1, hard_value = 0, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});
+		AddSetting({name = "max_distance_between_towns_and_towns", description = "Maximum distance between towns", easy_value = 128, medium_value = 64, hard_value = 32, custom_value = 128, flags = CONFIG_NONE, min_value = 20, max_value = 16384});
 		AddSetting({name = "restrict_speed_town_to_town", description = "Restrict maximum road speed for town to town connection", easy_value = 1, medium_value = 1, hard_value = 1, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});		
-		AddSetting({name = "speed_town_to_town", description = "Maximum road speed for town to town connection (km/h)", easy_value = 90, medium_value = 70, hard_value = 30, custom_value = 70, flags = CONFIG_NONE, min_value = 20, max_value = 255, step_size = 5});
+		AddSetting({name = "speed_town_to_town", description = "Maximum road speed for town to town connection (km/h)", easy_value = 90, medium_value = 70, hard_value = 50, custom_value = 90, flags = CONFIG_NONE, min_value = 20, max_value = 255, step_size = 5});
 	}
 }
 
 RegisterGS(FMainClass());
+

--- a/info.nut
+++ b/info.nut
@@ -33,19 +33,22 @@ class FMainClass extends GSInfo {
 	function MinVersionToLoad() { return 1; }
 
 	function GetSettings() {
-		AddSetting({name = "max_connected_towns", description = "Maximum number of neighbor towns to be connected", easy_value = 5, medium_value = 2, hard_value = 0, custom_value = 5, flags = CONFIG_NONE, min_value = 1, max_value = 16});
+		AddSetting({name = "max_connected_towns", description = "Maximum number of neighbor towns to be connected", easy_value = 5, medium_value = 5, hard_value = 2, custom_value = 5, flags = CONFIG_NONE, min_value = 1, max_value = 16});
 
-		AddSetting({name = "connect_cities_to_cities", description = "Connect cities to cities", easy_value = 1, medium_value = 1, hard_value = 1, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});
-		AddSetting({name = "max_distance_between_cities", description = "Maximum distance between cities", easy_value = 1024, medium_value = 512, hard_value = 256, custom_value = 1024, flags = CONFIG_NONE, min_value = 20, max_value = 16384});
-		AddSetting({name = "speed_city_to_city", description = "Maximum road speed for city to city connection (km/h)", easy_value = 130, medium_value = 130, hard_value = 90, custom_value = 5, flags = CONFIG_NONE, min_value = 20, max_value = 255, step_size = 5});
+		AddSetting({name = "connect_cities_to_cities", description = "----- Connect cities to cities -----", easy_value = 1, medium_value = 1, hard_value = 1, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});
+		AddSetting({name = "max_distance_between_cities", description = "Maximum distance between cities", easy_value = 1024, medium_value = 512, hard_value = 256, custom_value = 512, flags = CONFIG_NONE, min_value = 20, max_value = 16384});
+		AddSetting({name = "restrict_speed_city_to_city", description = "Restrict maximum road speed for city to city connection", easy_value = 0, medium_value = 0, hard_value = 1, custom_value = 0, flags = CONFIG_NONE + CONFIG_BOOLEAN});
+		AddSetting({name = "speed_city_to_city", description = "Maximum road speed for city to city connection (km/h)", easy_value = 130, medium_value = 130, hard_value = 90, custom_value = 130, flags = CONFIG_NONE, min_value = 20, max_value = 255, step_size = 5});
 
-		AddSetting({name = "connect_towns_to_cities", description = "Connect towns to cities", easy_value = 1, medium_value = 1, hard_value = 0, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});
-		AddSetting({name = "max_distance_between_towns_and_cities", description = "Maximum distance between towns and cities", easy_value = 512, medium_value = 256, hard_value = 128, custom_value = 512, flags = CONFIG_NONE, min_value = 20, max_value = 16384});
-		AddSetting({name = "speed_town_to_city", description = "Maximum road speed for town to city connection (km/h)", easy_value = 110, medium_value = 90, hard_value = 70, custom_value = 5, flags = CONFIG_NONE, min_value = 20, max_value = 255, step_size = 5});
+		AddSetting({name = "connect_towns_to_cities", description = "----- Connect towns to cities -----", easy_value = 1, medium_value = 1, hard_value = 0, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});
+		AddSetting({name = "max_distance_between_towns_and_cities", description = "Maximum distance between towns and cities", easy_value = 512, medium_value = 256, hard_value = 128, custom_value = 256, flags = CONFIG_NONE, min_value = 20, max_value = 16384});
+		AddSetting({name = "restrict_speed_town_to_city", description = "Restrict maximum road speed for town to city connection", easy_value = 0, medium_value = 1, hard_value = 1, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});		
+		AddSetting({name = "speed_town_to_city", description = "Maximum road speed for town to city connection (km/h)", easy_value = 110, medium_value = 90, hard_value = 70, custom_value = 90, flags = CONFIG_NONE, min_value = 20, max_value = 255, step_size = 5});
 
-		AddSetting({name = "connect_towns_to_towns", description = "Connect towns to neighbor", easy_value = 1, medium_value = 1, hard_value = 0, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});
-		AddSetting({name = "max_distance_between_towns_and_towns", description = "Maximum distance between towns and towns", easy_value = 256, medium_value = 128, hard_value = 64, custom_value = 256, flags = CONFIG_NONE, min_value = 20, max_value = 16384});
-		AddSetting({name = "speed_town_to_town", description = "Maximum road speed for town to town connection (km/h)", easy_value = 90, medium_value = 70, hard_value = 30, custom_value = 5, flags = CONFIG_NONE, min_value = 20, max_value = 255, step_size = 5});
+		AddSetting({name = "connect_towns", description = "----- Connect towns with towns -----", easy_value = 1, medium_value = 1, hard_value = 0, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});
+		AddSetting({name = "max_distance_between_towns", description = "Maximum distance between towns", easy_value = 256, medium_value = 128, hard_value = 64, custom_value = 128, flags = CONFIG_NONE, min_value = 20, max_value = 16384});
+		AddSetting({name = "restrict_speed_town_to_town", description = "Restrict maximum road speed for town to town connection", easy_value = 1, medium_value = 1, hard_value = 1, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});		
+		AddSetting({name = "speed_town_to_town", description = "Maximum road speed for town to town connection (km/h)", easy_value = 90, medium_value = 70, hard_value = 30, custom_value = 70, flags = CONFIG_NONE, min_value = 20, max_value = 255, step_size = 5});
 	}
 }
 

--- a/info.nut
+++ b/info.nut
@@ -35,7 +35,7 @@ class FMainClass extends GSInfo {
 	function GetSettings() {
 		AddSetting({name = "max_connected_towns", description = "Maximum number of neighbor towns to be connected", easy_value = 5, medium_value = 5, hard_value = 2, custom_value = 5, flags = CONFIG_NONE, min_value = 1, max_value = 16});
 
-		AddSetting({name = "connect_cities_to_cities", description = "----- Connect cities to cities -----", easy_value = 1, medium_value = 1, hard_value = 1, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});
+		AddSetting({name = "connect_cities_to_cities", description = "----- Connect cities -----", easy_value = 1, medium_value = 1, hard_value = 1, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});
 		AddSetting({name = "max_distance_between_cities", description = "Maximum distance between cities", easy_value = 1024, medium_value = 512, hard_value = 256, custom_value = 512, flags = CONFIG_NONE, min_value = 20, max_value = 16384});
 		AddSetting({name = "restrict_speed_city_to_city", description = "Restrict maximum road speed for city to city connection", easy_value = 0, medium_value = 0, hard_value = 1, custom_value = 0, flags = CONFIG_NONE + CONFIG_BOOLEAN});
 		AddSetting({name = "speed_city_to_city", description = "Maximum road speed for city to city connection (km/h)", easy_value = 130, medium_value = 130, hard_value = 90, custom_value = 130, flags = CONFIG_NONE, min_value = 20, max_value = 255, step_size = 5});
@@ -45,8 +45,8 @@ class FMainClass extends GSInfo {
 		AddSetting({name = "restrict_speed_town_to_city", description = "Restrict maximum road speed for town to city connection", easy_value = 0, medium_value = 1, hard_value = 1, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});		
 		AddSetting({name = "speed_town_to_city", description = "Maximum road speed for town to city connection (km/h)", easy_value = 110, medium_value = 90, hard_value = 70, custom_value = 90, flags = CONFIG_NONE, min_value = 20, max_value = 255, step_size = 5});
 
-		AddSetting({name = "connect_towns", description = "----- Connect towns with towns -----", easy_value = 1, medium_value = 1, hard_value = 0, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});
-		AddSetting({name = "max_distance_between_towns", description = "Maximum distance between towns", easy_value = 256, medium_value = 128, hard_value = 64, custom_value = 128, flags = CONFIG_NONE, min_value = 20, max_value = 16384});
+		AddSetting({name = "connect_towns_to_towns", description = "----- Connect towns to other towns -----", easy_value = 1, medium_value = 1, hard_value = 0, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});
+		AddSetting({name = "max_distance_between_towns_and_towns", description = "Maximum distance between towns", easy_value = 256, medium_value = 128, hard_value = 64, custom_value = 128, flags = CONFIG_NONE, min_value = 20, max_value = 16384});
 		AddSetting({name = "restrict_speed_town_to_town", description = "Restrict maximum road speed for town to town connection", easy_value = 1, medium_value = 1, hard_value = 1, custom_value = 1, flags = CONFIG_NONE + CONFIG_BOOLEAN});		
 		AddSetting({name = "speed_town_to_town", description = "Maximum road speed for town to town connection (km/h)", easy_value = 90, medium_value = 70, hard_value = 30, custom_value = 70, flags = CONFIG_NONE, min_value = 20, max_value = 255, step_size = 5});
 	}

--- a/make_tar.py
+++ b/make_tar.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import platform
 
 # ----------------------------------
 # Definitions:
@@ -28,11 +29,22 @@ if(version == -1):
 
 dir_name = gs_pack_name + "-v" + version
 tar_name = dir_name + ".tar"
-os.system("mkdir " + dir_name);
-os.system("xcopy /C /Y *.nut " + dir_name);
-os.system("xcopy /C /Y readme.txt " + dir_name);
-os.system("xcopy /C /Y license.txt " + dir_name);
-os.system("xcopy /C /Y changelog.txt " + dir_name);
-os.system("xcopy /E /C /Y lang " + dir_name);
-os.system("tar -cf " + tar_name + " " + dir_name);
-os.system("rd /S /Q " + dir_name);
+os.makedirs(dir_name, exist_ok = True)
+
+if platform.system() == 'Windows':
+	os.system("xcopy /D *.nut " + dir_name);
+	os.system("xcopy /D readme.txt " + dir_name);
+	os.system("xcopy /D license.txt " + dir_name);
+	os.system("xcopy /D changelog.txt " + dir_name);
+	os.system("xcopy /D /E /S lang " + dir_name);
+	os.system("tar -cf " + tar_name + " " + dir_name);
+	os.system("rd /S /Q " + dir_name);
+# POSIX
+else:
+	os.system("cp -u *.nut " + dir_name);
+	os.system("cp -u readme.txt " + dir_name);
+	os.system("cp -u license.txt " + dir_name);
+	os.system("cp -u changelog.txt " + dir_name);
+	os.system("cp -ur lang " + dir_name);
+	os.system("tar -cf " + tar_name + " " + dir_name);
+	os.system("rm -r " + dir_name)

--- a/make_tar.py
+++ b/make_tar.py
@@ -37,7 +37,7 @@ if platform.system() == 'Windows':
 	os.system("xcopy /D license.txt " + dir_name);
 	os.system("xcopy /D changelog.txt " + dir_name);
 	os.system("xcopy /D /E /S lang " + dir_name);
-	os.system("tar -cf " + tar_name + " " + dir_name);
+	os.system("tar -vcf " + tar_name + " " + dir_name);
 	os.system("rd /S /Q " + dir_name);
 # POSIX
 else:
@@ -46,5 +46,5 @@ else:
 	os.system("cp -u license.txt " + dir_name);
 	os.system("cp -u changelog.txt " + dir_name);
 	os.system("cp -ur lang " + dir_name);
-	os.system("tar -cf " + tar_name + " " + dir_name);
+	os.system("tar -vcf " + tar_name + " " + dir_name);
 	os.system("rm -r " + dir_name)


### PR DESCRIPTION
A small change allowing the script to build roads with no speed limit (highways, expressways, etc.)

When the corresponding GSList is sorted those naturally fall in priority below lowest speed limit road types as they technically have speed limit zero, and the script is unable to use them. The code now truncates the road types list of items with values above 0. If that leaves not a single road type in the list, it proceeds as before, otherwise using the first of the left.

There are respective settings in GUI so that the player may choose whether to enforce speed limits.

Another thing is that make_tar.py is now cross-platform and POSIX compliant, and therefore should work on most operating systems.

And finally it changes some of the default values in info.nut.